### PR TITLE
test: adiciona testes de integração

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,18 @@
+const dotenv = require("dotenv");
+
+dotenv.config({
+  path: ".env.development",
+});
+
+const nextJest = require("next/jest");
+
+const createJestConfig = nextJest({
+  dir: ".",
+});
+
+const jestConfig = createJestConfig({
+  moduleDirectories: ["node_modules", "<rootDir>"],
+  testTimeout: 60000,
+});
+
+module.exports = jestConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "async-retry": "1.3.3",
         "dotenv": "16.5.0",
         "dotenv-expand": "12.0.2",
         "next": "15.3.3",
@@ -3433,6 +3434,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/at-least-node": {
@@ -10032,6 +10042,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "async-retry": "1.3.3",
     "dotenv": "16.5.0",
     "dotenv-expand": "12.0.2",
     "next": "15.3.3",

--- a/tests/integration/api/v1/migrations/get.test.js
+++ b/tests/integration/api/v1/migrations/get.test.js
@@ -1,0 +1,17 @@
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabase();
+});
+
+describe("GET /api/v1/migrations", () => {
+  test("Retrieving pending migrations", async () => {
+    const response = await fetch("http://localhost:3000/api/v1/migrations");
+    const responseBody = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(Array.isArray(responseBody)).toBe(true);
+    expect(responseBody.length).toBeGreaterThan(0);
+  });
+});

--- a/tests/integration/api/v1/migrations/post.test.js
+++ b/tests/integration/api/v1/migrations/post.test.js
@@ -1,0 +1,32 @@
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabase();
+});
+
+describe("POST /api/v1/migrations", () => {
+  describe("Running pending migrations", () => {
+    test("For the first time", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/migrations", {
+        method: "POST",
+      });
+      const response1Body = await response1.json();
+
+      expect(response1.status).toBe(201);
+      expect(Array.isArray(response1Body)).toBe(true);
+      expect(response1Body.length).toBeGreaterThan(0);
+    });
+
+    test("For the second time", async () => {
+      const response2 = await fetch("http://localhost:3000/api/v1/migrations", {
+        method: "POST",
+      });
+      const response2Body = await response2.json();
+
+      expect(response2.status).toBe(200);
+      expect(Array.isArray(response2Body)).toBe(true);
+      expect(response2Body.length).toBe(0);
+    });
+  });
+});

--- a/tests/integration/api/v1/status/get.test.js
+++ b/tests/integration/api/v1/status/get.test.js
@@ -1,0 +1,19 @@
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+
+describe("GET /api/v1/status", () => {
+  test("Retrieving current system status", async () => {
+    const response = await fetch("http://localhost:3000/api/v1/status");
+    const responseBody = await response.json();
+    const parsedUpdatedAt = new Date(responseBody.updated_at).toISOString();
+
+    expect(response.status).toBe(200);
+    expect(responseBody.updated_at).toEqual(parsedUpdatedAt);
+    expect(responseBody.dependencies.database.version).toEqual("17.5");
+    expect(responseBody.dependencies.database.max_connections).toEqual(100);
+    expect(responseBody.dependencies.database.open_connections).toEqual(1);
+  });
+});

--- a/tests/integration/api/v1/status/post.test.js
+++ b/tests/integration/api/v1/status/post.test.js
@@ -1,0 +1,22 @@
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+
+describe("POST /api/v1/status", () => {
+  test("Retrieving current system status", async () => {
+    const response = await fetch("http://localhost:3000/api/v1/status", {
+      method: "POST",
+    });
+    const responseBody = await response.json();
+
+    expect(response.status).toBe(405);
+    expect(responseBody).toEqual({
+      name: "MethodNotAllowedError",
+      message: "Método POST não permitido para o endpoint: /api/v1/status",
+      action: "Verifique se o método HTTP enviado é válido para este endpoint.",
+      status_code: 405,
+    });
+  });
+});

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -1,0 +1,38 @@
+import database from "infra/database.js";
+import migrator from "models/migrator.js";
+import retry from "async-retry";
+
+async function waitForAllServices() {
+  await waitForWebServer();
+
+  async function waitForWebServer() {
+    return retry(fetchStatusPage, {
+      retries: 100,
+      maxTimeout: 1000,
+    });
+
+    async function fetchStatusPage() {
+      const response = await fetch("http://localhost:3000/api/v1/status");
+
+      if (response.status !== 200) {
+        throw Error();
+      }
+    }
+  }
+}
+
+async function clearDatabase() {
+  await database.query("drop schema public cascade; create schema public;");
+}
+
+async function runPendingMigrations() {
+  await migrator.runPendingMigrations();
+}
+
+const orchestrator = {
+  waitForAllServices,
+  clearDatabase,
+  runPendingMigrations,
+};
+
+export default orchestrator;


### PR DESCRIPTION
- Adiciona utilitário `orchestrator.js` para setup, limpeza e execução de migrações no ambiente de testes.
- Implementa testes de integração para os endpoints `/api/v1/migrations` (`GET` e `POST`) e `/api/v1/status` (`GET` e `POST`), cobrindo cenários de sucesso e erro.
- Cria configuração customizada do Jest para facilitar execução e isolamento dos testes.
- Instala a dependência `async-retry` para garantir que os testes só iniciem após o servidor estar pronto.
- Garante maior robustez, confiabilidade e cobertura automatizada para a API.